### PR TITLE
Consumed sse spec with core security upgrade.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <jmh.profilers.version>0.1.3</jmh.profilers.version>
 
     <k3po.version>3.0.0-alpha-83</k3po.version>
-    <k3po.nukleus.ext.version>develop-SNAPSHOT</k3po.nukleus.ext.version>
+    <k3po.nukleus.ext.version>0.11</k3po.nukleus.ext.version>
 
     <nukleus.plugin.version>0.12</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <nukleus.plugin.version>0.12</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
-    <nukleus.sse.spec.version>develop-SNAPSHOT</nukleus.sse.spec.version>
+    <nukleus.sse.spec.version>0.5</nukleus.sse.spec.version>
     <reaktor.version>0.27</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <nukleus.version>0.11</nukleus.version>
 
     <nukleus.sse.spec.version>develop-SNAPSHOT</nukleus.sse.spec.version>
-    <reaktor.version>develop-SNAPSHOT</reaktor.version>
+    <reaktor.version>0.27</reaktor.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -41,21 +41,21 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <checkstyle.config.location>src/conf/checkstyle/configuration.xml</checkstyle.config.location>
     <checkstyle.suppressions.location>src/conf/checkstyle/suppressions.xml</checkstyle.suppressions.location>
-    <jacoco.coverage.ratio>0.53</jacoco.coverage.ratio>
-    <jacoco.missed.count>26</jacoco.missed.count>
+    <jacoco.coverage.ratio>0.42</jacoco.coverage.ratio>
+    <jacoco.missed.count>41</jacoco.missed.count>
 
     <junit.version>4.12</junit.version>
     <jmh.version>1.17.4</jmh.version>
     <jmh.profilers.version>0.1.3</jmh.profilers.version>
 
-    <k3po.version>3.0.0-alpha-82</k3po.version>
-    <k3po.nukleus.ext.version>0.10</k3po.nukleus.ext.version>
+    <k3po.version>3.0.0-alpha-83</k3po.version>
+    <k3po.nukleus.ext.version>develop-SNAPSHOT</k3po.nukleus.ext.version>
 
     <nukleus.plugin.version>0.12</nukleus.plugin.version>
     <nukleus.version>0.11</nukleus.version>
 
-    <nukleus.sse.spec.version>0.4</nukleus.sse.spec.version>
-    <reaktor.version>0.26</reaktor.version>
+    <nukleus.sse.spec.version>develop-SNAPSHOT</nukleus.sse.spec.version>
+    <reaktor.version>develop-SNAPSHOT</reaktor.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-sse.spec/pull/1, etc