### PR TITLE
End with extension (last event id)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
+  - git clone https://github.com/cmebarrow/nukleus-sse.spec
+  - cd nukleus-sse.spec
+  - git checkout end_with_extension
+  - mvn clean install -DskipTests
+  - cd ..
 jdk:
   - oraclejdk9
 install: mvn -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ dist: trusty
 language: java
 before_install:
   - rm ~/.m2/settings.xml
-  - git clone https://github.com/cmebarrow/nukleus-sse.spec
-  - cd nukleus-sse.spec
-  - git checkout end_with_extension
-  - mvn clean install -DskipTests
-  - cd ..
 jdk:
   - oraclejdk9
 install: mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.22</nukleus.version>
 
-    <nukleus.sse.spec.version>develop-SNAPSHOT</nukleus.sse.spec.version>
+    <nukleus.sse.spec.version>0.22</nukleus.sse.spec.version>
     <reaktor.version>0.59</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.22</nukleus.version>
 
-    <nukleus.sse.spec.version>0.21</nukleus.sse.spec.version>
+    <nukleus.sse.spec.version>develop-SNAPSHOT</nukleus.sse.spec.version>
     <reaktor.version>0.59</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/sse/internal/stream/ServerStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/sse/internal/stream/ServerStreamFactory.java
@@ -666,7 +666,7 @@ public final class ServerStreamFactory implements StreamFactory
                 }
                 else
                 {
-                    // TODO: Allocate a buffer slot instead of using stack
+                    // Rare condition where there is insufficient window to write id: last_event_id\n\n
                     throttleState = this::throttleAfterEndRequested;
                     lastHttpDataFrameBeforeEnd = new UnsafeBuffer(ByteBuffer.allocate(frame.sizeof()));
                     lastHttpDataFrameBeforeEnd.putBytes(0, frame.buffer(), frame.offset(), frame.sizeof());

--- a/src/main/java/org/reaktivity/nukleus/sse/internal/stream/ServerStreamFactoryBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/sse/internal/stream/ServerStreamFactoryBuilder.java
@@ -49,6 +49,7 @@ public final class ServerStreamFactoryBuilder implements StreamFactoryBuilder
     private MutableDirectBuffer writeBuffer;
     private LongSupplier supplyStreamId;
     private LongSupplier supplyTrace;
+    private Supplier<BufferPool> supplyBufferPool;
     private LongSupplier supplyCorrelationId;
 
     private Function<RouteFW, LongSupplier> supplyWriteFrameCounter;
@@ -127,6 +128,7 @@ public final class ServerStreamFactoryBuilder implements StreamFactoryBuilder
     public StreamFactoryBuilder setBufferPoolSupplier(
         Supplier<BufferPool> supplyBufferPool)
     {
+        this.supplyBufferPool = supplyBufferPool;
         return this;
     }
 
@@ -207,6 +209,7 @@ public final class ServerStreamFactoryBuilder implements StreamFactoryBuilder
                 config,
                 router,
                 writeBuffer,
+                supplyBufferPool.get(),
                 supplyStreamId,
                 supplyTrace,
                 supplyCorrelationId,

--- a/src/main/java/org/reaktivity/nukleus/sse/internal/util/Flags.java
+++ b/src/main/java/org/reaktivity/nukleus/sse/internal/util/Flags.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.sse.internal.util;
+
+public final class Flags
+{
+    public static final byte FIN = 0x01;
+    public static final byte INIT = 0x02;
+
+    public static  boolean fin(byte flags)
+    {
+        return (flags & FIN) != 0;
+    }
+
+}

--- a/src/test/java/org/reaktivity/nukleus/sse/internal/streams/server/ReconnectIT.java
+++ b/src/test/java/org/reaktivity/nukleus/sse/internal/streams/server/ReconnectIT.java
@@ -50,9 +50,29 @@ public class ReconnectIT
     @Test
     @Specification({
         "${route}/server/controller",
+        "${client}/request.header.last.event.id.and.data/request",
+        "${server}/last.event.id.data/response" })
+    public void shouldReconnectWithLastEventIdOnData() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/server/controller",
         "${client}/request.header.last.event.id/request",
-        "${server}/last.event.id/response" })
-    public void shouldReconnectWithLastEventId() throws Exception
+        "${server}/last.event.id.end/response" })
+    public void shouldReconnectWithLastEventIdOnEnd() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/request.header.last.event.id.fragmented/request",
+        "${server}/last.event.id.end.fragmented/response" })
+    public void shouldReconnectWithLastEventIdOnEndFragmented() throws Exception
     {
         k3po.finish();
     }


### PR DESCRIPTION
Requires https://github.com/reaktivity/nukleus-sse.spec/pull/8

Added support for last event id in `END` extension data. This causes an event to be written with just the `id:` field before writing the `END` to the encoded response stream.